### PR TITLE
Allow user to set height and port from magic line command

### DIFF
--- a/colabxterm/notebook.py
+++ b/colabxterm/notebook.py
@@ -76,6 +76,26 @@ def _xterm_magic(args_string):
     parsed_args = shlex.split(args_string, comments=True, posix=True)
     height = 800
     port = 10000
+
+    # setup parameter from parsed_args to support the following format
+    # %xterm height=300 port=400
+    for parameter in parsed_args:
+      kv_pair:list[str] = str(parameter).split('=')
+      if(len(kv_pair)==2):
+        k=kv_pair[0]
+        v=kv_pair[1]
+        try:
+          vint = int(v)
+        except ValueError:
+          pass
+        else:
+          if(k=="height"):
+            height=int(v)
+          elif(k=="port"):
+            port=int(v)
+    # clean parsed_args as empty list to avoid the disability of the magic line command
+    parsed_args=[]
+
     while True:
         if not is_port_in_use(port):
             break

--- a/colabxterm/notebook.py
+++ b/colabxterm/notebook.py
@@ -77,23 +77,19 @@ def _xterm_magic(args_string):
     height = 800
     port = 10000
 
-    # setup parameter from parsed_args to support the following format
-    # %xterm height=300 port=400
+    # Setup parameter from parsed_args to support the following format.
+    # %xterm height=300 port=10001
     for parameter in parsed_args:
-      kv_pair:list[str] = str(parameter).split('=')
-      if(len(kv_pair)==2):
-        k=kv_pair[0]
-        v=kv_pair[1]
-        try:
-          vint = int(v)
-        except ValueError:
-          pass
-        else:
-          if(k=="height"):
-            height=int(v)
-          elif(k=="port"):
-            port=int(v)
-    # clean parsed_args as empty list to avoid the disability of the magic line command
+        kv_pair:list[str] = str(parameter).split('=')
+        if len(kv_pair) == 2:
+            k = kv_pair[0]
+            v = kv_pair[1]
+            if v.isdigit():
+                if k == "height":
+                    height = int(v)
+                elif k == "port":
+                    port = int(v)
+    # Clean parsed_args as an empty list to avoid the disability of the magic line command.
     parsed_args=[]
 
     while True:


### PR DESCRIPTION
We can use the following magic line command to set up the height of the cell, and so do the port.
```
%xterm height=300 port=10001
```
The following YouTube shows how it works (Select 1440p)
https://www.youtube.com/watch?v=0eRO0xNzJ-s

This PR is also related to this issue 
- https://github.com/InfuseAI/colab-xterm/issues/2